### PR TITLE
Fix unpack_columns to convert to uint first

### DIFF
--- a/core/rs/core/src/pack_columns.rs
+++ b/core/rs/core/src/pack_columns.rs
@@ -157,7 +157,8 @@ pub fn unpack_columns(data: &[u8]) -> Result<Vec<ColumnValue>, ResultCode> {
                 if buf.remaining() < intlen {
                     return Err(ResultCode::ABORT);
                 }
-                ret.push(ColumnValue::Integer(buf.get_int(intlen)));
+                let unsigned = buf.get_uint(intlen);
+                ret.push(ColumnValue::Integer(unsigned as i64));
             }
             Some(ColumnType::Null) => {
                 ret.push(ColumnValue::Null);
@@ -166,7 +167,7 @@ pub fn unpack_columns(data: &[u8]) -> Result<Vec<ColumnValue>, ResultCode> {
                 if buf.remaining() < intlen {
                     return Err(ResultCode::ABORT);
                 }
-                let len = buf.get_int(intlen) as usize;
+                let len = buf.get_uint(intlen) as usize;
                 if buf.remaining() < len {
                     return Err(ResultCode::ABORT);
                 }

--- a/core/rs/integration_check/src/t/pack_columns.rs
+++ b/core/rs/integration_check/src/t/pack_columns.rs
@@ -190,29 +190,6 @@ fn test_unpack_columns() -> Result<(), ResultCode> {
         }
     }
 
-    db.db.exec_safe("DELETE FROM bar")?;
-    let float_col: [f64; 6] = [1.0, -1.0, f64::MIN, f64::MAX, 2.0, 0.7899];
-
-    for f in float_col {
-        let insert_stmt = db.db.prepare_v2("INSERT INTO bar VALUES (?)")?;
-        insert_stmt.bind_double(1, f)?;
-        insert_stmt.step()?;
-
-        let select_stmt = db
-            .db
-            .prepare_v2("SELECT crsql_pack_columns(id) FROM bar where id = ?")?;
-        select_stmt.bind_double(1, f)?;
-        select_stmt.step()?;
-        let result = select_stmt.column_blob(0)?;
-        let unpacked = unpack_columns(result)?;
-        assert!(unpacked.len() == 1);
-        if let ColumnValue::Float(i) = unpacked[0] {
-            assert!(i == f);
-        } else {
-            assert!("unexpected type" == "");
-        }
-    }
-
     Ok(())
 }
 

--- a/core/rs/integration_check/src/t/pack_columns.rs
+++ b/core/rs/integration_check/src/t/pack_columns.rs
@@ -135,6 +135,84 @@ fn test_unpack_columns() -> Result<(), ResultCode> {
     select_stmt.step()?;
     assert!(select_stmt.column_blob(0)? == blob);
 
+    db.db.exec_safe("CREATE TABLE bar (id PRIMARY KEY)")?;
+    let int_col: [i64; 7] = [
+        1,
+        -1,
+        i64::MAX,
+        i64::MIN,
+        i8::MAX as i64,
+        i16::MIN as i64,
+        10156800_i64,
+    ];
+
+    for i in int_col {
+        let insert_stmt = db.db.prepare_v2("INSERT INTO bar VALUES (?)")?;
+        insert_stmt.bind_int64(1, i)?;
+        insert_stmt.step()?;
+
+        let select_stmt = db
+            .db
+            .prepare_v2("SELECT crsql_pack_columns(id) FROM bar where id = ?")?;
+        select_stmt.bind_int64(1, i)?;
+        select_stmt.step()?;
+        let result = select_stmt.column_blob(0)?;
+        let unpacked = unpack_columns(result)?;
+        assert!(unpacked.len() == 1);
+        if let ColumnValue::Integer(i) = unpacked[0] {
+            assert!(i == i);
+        } else {
+            assert!("unexpected type" == "");
+        }
+    }
+
+    db.db.exec_safe("DELETE FROM bar")?;
+    let text_col: [&str; 4] = ["a", ",", "-abcdefghijklmnopqrstuvwxyz1234567890?!", ""];
+
+    for txt in text_col {
+        let insert_stmt = db.db.prepare_v2("INSERT INTO bar VALUES (?)")?;
+        insert_stmt.bind_text(1, txt, sqlite::Destructor::STATIC)?;
+        insert_stmt.step()?;
+
+        let select_stmt = db
+            .db
+            .prepare_v2("SELECT crsql_pack_columns(id) FROM bar where id = ?")?;
+        select_stmt.bind_text(1, txt, sqlite::Destructor::STATIC)?;
+        select_stmt.step()?;
+        let result = select_stmt.column_blob(0)?;
+        let unpacked = unpack_columns(result)?;
+        assert!(unpacked.len() == 1);
+        libc_print::std_name::println!("unpacked: {:?}", txt);
+        if let ColumnValue::Text(i) = &unpacked[0] {
+            assert!(i == txt);
+        } else {
+            assert!("unexpected type" == "");
+        }
+    }
+
+    db.db.exec_safe("DELETE FROM bar")?;
+    let float_col: [f64; 6] = [1.0, -1.0, f64::MIN, f64::MAX, 2.0, 0.7899];
+
+    for f in float_col {
+        let insert_stmt = db.db.prepare_v2("INSERT INTO bar VALUES (?)")?;
+        insert_stmt.bind_double(1, f)?;
+        insert_stmt.step()?;
+
+        let select_stmt = db
+            .db
+            .prepare_v2("SELECT crsql_pack_columns(id) FROM bar where id = ?")?;
+        select_stmt.bind_double(1, f)?;
+        select_stmt.step()?;
+        let result = select_stmt.column_blob(0)?;
+        let unpacked = unpack_columns(result)?;
+        assert!(unpacked.len() == 1);
+        if let ColumnValue::Float(i) = unpacked[0] {
+            assert!(i == f);
+        } else {
+            assert!("unexpected type" == "");
+        }
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Upgrading the `bytes` to 1.10.1 will break the `pack_columns` function as `get_int` would now do a sign extension first before conversion. See https://github.com/superfly/corrosion/pull/358