### PR TITLE
fix(core): return void from crsql_rollback_hook to match SQLite ABI

### DIFF
--- a/core/rs/core/src/commit.rs
+++ b/core/rs/core/src/commit.rs
@@ -2,7 +2,6 @@ use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
 use core::{
     ffi::{c_int, c_void},
     mem,
-    ptr::null,
 };
 
 use sqlite_nostd::ResultCode;
@@ -23,10 +22,13 @@ pub unsafe extern "C" fn crsql_commit_hook(user_data: *mut c_void) -> c_int {
     ResultCode::OK as c_int
 }
 
+// SQLite's rollback-hook callback is `void(*)(void*)` (see sqlite3.h and the C decl in
+// crsqlite.c). Returning a value gave this function the wasm type `(i32)->i32`, which
+// mismatches the `(i32)->void` `call_indirect` in sqlite3RollbackAll and traps under the
+// staticlib WASM build. Return void to match.
 #[no_mangle]
-pub unsafe extern "C" fn crsql_rollback_hook(user_data: *mut c_void) -> *const c_void {
+pub unsafe extern "C" fn crsql_rollback_hook(user_data: *mut c_void) {
     commit_or_rollback_reset(user_data as *mut crsql_ExtData);
-    null()
 }
 
 pub unsafe fn commit_or_rollback_reset(ext_data: *mut crsql_ExtData) {


### PR DESCRIPTION
## Problem

`crsql_rollback_hook` is declared to return `*const c_void`:

```rust
pub unsafe extern "C" fn crsql_rollback_hook(user_data: *mut c_void) -> *const c_void {
    commit_or_rollback_reset(user_data as *mut crsql_ExtData);
    null()
}
```

But SQLite's rollback-hook callback is `void (*)(void*)` (see `sqlite3.h`), and the C
declaration/registration in `src/crsqlite.c` correctly uses `void`:

```c
void crsql_rollback_hook(void *pUserData);
...
sqlite3_rollback_hook(db, crsql_rollback_hook, pExtData);
```

The extra return value gives the function the type `(i32) -> i32` instead of
`(i32) -> void`. On native ABIs this is harmless (a `void`-expecting caller just ignores
the returned register), so it's latent. But **WebAssembly `call_indirect` enforces exact
function-type equality**, so when `sqlite3RollbackAll` invokes the rollback hook as
`(i32) -> void`, it traps:

```
RuntimeError: function signature mismatch
  at sqlite3RollbackAll
  at sqlite3VdbeExec
  ...
  at crsql_core::x_crsql_as_crr
```

This makes `crsql_as_crr` (and therefore all CRR/CRDT functionality) fail on WASM builds
that link the Rust core as a static archive (i.e. any build without whole-program
cross-language LTO, which previously masked the mismatch by unifying types during codegen).

## Fix

Return `void` from `crsql_rollback_hook`, matching SQLite and the existing C declaration.

## How it was found

Building cr-sqlite to WASM (emscripten, Rust core as `staticlib`) and running
`SELECT crsql_as_crr('t')` on an OPFS-backed database. With a symbol-mapped debug build,
the trap resolved to `sqlite3RollbackAll` calling the registered rollback hook. After this
fix, `crsql_as_crr` / `crsql_changes` work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)